### PR TITLE
Add rate limiting options

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,28 @@ config :logger_sentry,
   ]
 ```
 
+## Rate Limiting
+
+Sentry can be configured with a rate limit on the Sentry servers.
+Any messages received faster than that limit will not be processed.
+In order to avoid unnecessary traffic and potentially getting IP-blocked
+by Sentry, it is recommended to add rate limiting on your own servers.
+
+By default, `LoggerSentry` does not enforce rate limits. Rate limiting can be added through your project config files like this:
+
+```
+import Config
+
+config :logger_sentry, LoggerSentry.RateLimiter,
+    rate_limiter_module: LoggerSentry.RateLimiter.TokenBucket,
+    rate_limiter_options: [token_count: 20, interval_ms: 60_000]
+```
+
+`LoggerSentry` comes with a simple token bucket algorithm.
+You may add other rate-limiting algorithms by creating a module that
+conforms to the `LoggerSentry.RateLimiter` module. Then setting
+`rate_limiter_module` to your custom module.
+
 ## Example
 
 [use example](https://github.com/Tubitv/logger_sentry/wiki/Use-example)

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :logger_sentry,
   fingerprints_mods: [

--- a/lib/logger_sentry.ex
+++ b/lib/logger_sentry.ex
@@ -175,7 +175,7 @@ defmodule Logger.Backends.Sentry do
     end
   else
     defp send_sentry_log(_log_level, output, options) do
-      LoggerSentry.send_rate_limited(output, options)
+      LoggerSentry.RateLimiter.send_rate_limited(output, options)
     end
   end
 end

--- a/lib/logger_sentry.ex
+++ b/lib/logger_sentry.ex
@@ -175,10 +175,7 @@ defmodule Logger.Backends.Sentry do
     end
   else
     defp send_sentry_log(_log_level, output, options) do
-      Sentry.capture_message(output, options)
-      :ok
+      LoggerSentry.send_rate_limited(output, options)
     end
   end
-
-  # __end_of_module__
 end

--- a/lib/logger_sentry/application.ex
+++ b/lib/logger_sentry/application.ex
@@ -1,0 +1,16 @@
+defmodule LoggerSentry.Application do
+  @moduledoc false
+
+  use Application
+
+  def start(_type, _args) do
+    opts = [strategy: :one_for_one, name: LoggerSentry.Supervisor]
+    rate_limit_options = Application.get_env(:logger_sentry, LoggerSentry.RateLimiter, [])
+
+    children = [
+      {LoggerSentry.RateLimiter, rate_limit_options}
+    ]
+
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/lib/logger_sentry/rate_limiter.ex
+++ b/lib/logger_sentry/rate_limiter.ex
@@ -61,4 +61,14 @@ defmodule LoggerSentry.RateLimiter do
         {:noreply, new_strategy}
     end
   end
+
+  # Ignore any messages produced from Task.Supervisor.async_nolink via Sentry.
+
+  def handle_info({:DOWN, _ref, _type, _pid, _reason}, state) do
+    {:noreply, state}
+  end
+
+  def handle_info({ref, _result}, state) when is_reference(ref) do
+    {:noreply, state}
+  end
 end

--- a/lib/logger_sentry/rate_limiter.ex
+++ b/lib/logger_sentry/rate_limiter.ex
@@ -1,0 +1,64 @@
+defmodule LoggerSentry.RateLimiter do
+  @moduledoc """
+  The top-level logic for rate limiting requests. Must be given a
+  LoggerSentry.RateLimiter.Strategy to provide the details of the 
+  actual rate-limiting algorithm. The algorithm is specified by the
+  application config. The following example sets a rate limit of
+  20 requests per minute using the token bucket algorithm.
+
+  ```
+  import Config
+
+  config :logger_sentry, LoggerSentry.RateLimiter,
+    rate_limiter_module: LoggerSentry.RateLimiter.TokenBucket,
+    rate_limiter_options: [token_count: 20, interval_ms: 60_000]
+  ```
+
+  If no strategy is configured, then defaults to the strategy
+  LoggerSentry.RateLimiter.NoLimit. As implied by the name, this 
+  doesn't do any rate limiting.
+
+  You may provide your own rate limiters as long as they conform to the 
+  `LoggerSentry.RateLimiter` behaviour.
+  """
+
+  @type opts :: keyword()
+  @type strategy :: __MODULE__.Strategy
+
+  @callback init(opts()) :: strategy()
+  @callback check(strategy()) :: {:ok | :skip, strategy()}
+
+  use GenServer
+
+  @name __MODULE__
+
+  def start_link(opts) do
+    name = Keyword.get(opts, :name, @name)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  def send_rate_limited(rate_limiter \\ @name, output, options) do
+    GenServer.cast(rate_limiter, {:send_rate_limited, output, options})
+  end
+
+  ## GenServer callbacks
+
+  def init(opts) do
+    module = Keyword.get(opts, :rate_limiter_module) || __MODULE__.NoLimit
+    options = Keyword.get(opts, :rate_limiter_options) || []
+    strategy = module.init(options)
+
+    {:ok, strategy}
+  end
+
+  def handle_cast({:send_rate_limited, output, options}, strategy) do
+    case strategy.module.check(strategy) do
+      {:ok, new_strategy} ->
+        Sentry.capture_message(output, options)
+        {:noreply, new_strategy}
+
+      {:skip, new_strategy} ->
+        {:noreply, new_strategy}
+    end
+  end
+end

--- a/lib/logger_sentry/rate_limiter/no_limit.ex
+++ b/lib/logger_sentry/rate_limiter/no_limit.ex
@@ -1,0 +1,15 @@
+defmodule LoggerSentry.RateLimiter.NoLimit do
+  alias LoggerSentry.RateLimiter.Strategy
+
+  @behaviour LoggerSentry.RateLimiter
+
+  @impl LoggerSentry.RateLimiter
+  def init(_opts) do
+    %Strategy{module: __MODULE__, state: nil}
+  end
+
+  @impl LoggerSentry.RateLimiter
+  def check(strategy) do
+    {:ok, strategy}
+  end
+end

--- a/lib/logger_sentry/rate_limiter/strategy.ex
+++ b/lib/logger_sentry/rate_limiter/strategy.ex
@@ -1,0 +1,18 @@
+defmodule LoggerSentry.RateLimiter.Strategy do
+  @moduledoc """
+  A struct holding common data for rate-limiting strategies.
+  The `module` must be the name of module that conforms to the
+  `LoggerSentry.RateLimiter` behaviour. The `state` may be used
+  however the module sees fit.
+  """
+
+  @enforce_keys [:module, :state]
+  defstruct [:module, :state]
+
+  @type t() :: %__MODULE__{module: atom(), state: any()}
+
+  @spec new(atom(), any()) :: t()
+  def new(module, state) when is_atom(module) do
+    %__MODULE__{module: module, state: state}
+  end
+end

--- a/lib/logger_sentry/rate_limiter/strategy.ex
+++ b/lib/logger_sentry/rate_limiter/strategy.ex
@@ -1,7 +1,7 @@
 defmodule LoggerSentry.RateLimiter.Strategy do
   @moduledoc """
   A struct holding common data for rate-limiting strategies.
-  The `module` must be the name of module that conforms to the
+  The `module` must be the name of a module that conforms to the
   `LoggerSentry.RateLimiter` behaviour. The `state` may be used
   however the module sees fit.
   """

--- a/lib/logger_sentry/rate_limiter/token_bucket.ex
+++ b/lib/logger_sentry/rate_limiter/token_bucket.ex
@@ -4,7 +4,7 @@ defmodule LoggerSentry.RateLimiter.TokenBucket do
   Essentially, in some time period (ex. one minute), there are
   X number of tokens available. One request consumes one token.
   If no tokens, then no more requests may run. After the time 
-  interval has elapsed, the token count is restore to max.
+  interval has elapsed, the token count is restored to max.
   """
 
   alias LoggerSentry.RateLimiter.Strategy

--- a/lib/logger_sentry/rate_limiter/token_bucket.ex
+++ b/lib/logger_sentry/rate_limiter/token_bucket.ex
@@ -1,0 +1,67 @@
+defmodule LoggerSentry.RateLimiter.TokenBucket do
+  @moduledoc """
+  An implementation of a token bucket rate-limiting strategy.
+  Essentially, in some time period (ex. one minute), there are
+  X number of tokens available. One request consumes one token.
+  If no tokens, then no more requests may run. After the time 
+  interval has elapsed, the token count is restore to max.
+  """
+
+  alias LoggerSentry.RateLimiter.Strategy
+
+  @behaviour LoggerSentry.RateLimiter
+
+  @enforce_keys [:next_refresh, :tokens, :max_tokens, :interval_ms, :time_now]
+  defstruct [:next_refresh, :tokens, :max_tokens, :interval_ms, :time_now]
+
+  @impl LoggerSentry.RateLimiter
+  def init(opts) do
+    max_tokens = Keyword.get(opts, :token_count, 60)
+    interval_ms = Keyword.get(opts, :interval_ms, :timer.minutes(1))
+    time_now = Keyword.get(opts, :time_now, &now/0)
+
+    state = %__MODULE__{
+      next_refresh: next_refresh_time_from_now(time_now.(), interval_ms),
+      tokens: max_tokens,
+      max_tokens: max_tokens,
+      interval_ms: interval_ms,
+      time_now: time_now
+    }
+
+    Strategy.new(__MODULE__, state)
+  end
+
+  @impl LoggerSentry.RateLimiter
+  def check(strategy = %Strategy{state: state}) do
+    {status, new_state} =
+      cond do
+        # Time interval elapsed, refill tokens and consume one.
+        state.time_now.() >= state.next_refresh ->
+          next_refresh = next_refresh_time_from_now(state)
+          tokens = state.max_tokens - 1
+          {:ok, %__MODULE__{state | next_refresh: next_refresh, tokens: tokens}}
+
+        # Consume a token, if any present.
+        state.tokens > 0 ->
+          {:ok, %__MODULE__{state | tokens: state.tokens - 1}}
+
+        # No more tokens, skip the request.
+        true ->
+          {:skip, state}
+      end
+
+    {status, %Strategy{strategy | state: new_state}}
+  end
+
+  defp now() do
+    :erlang.monotonic_time(:millisecond)
+  end
+
+  defp next_refresh_time_from_now(%__MODULE__{interval_ms: interval_ms, time_now: time_now}) do
+    next_refresh_time_from_now(time_now.(), interval_ms)
+  end
+
+  defp next_refresh_time_from_now(now, interval_ms) do
+    now + interval_ms
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule LoggerSentry.Mixfile do
   def project do
     [
       app: :logger_sentry,
-      version: "0.6.1",
+      version: "0.7.0",
       elixir: "~> 1.7",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,
@@ -16,7 +16,10 @@ defmodule LoggerSentry.Mixfile do
   end
 
   def application do
-    [extra_applications: [:logger]]
+    [
+      extra_applications: [:logger],
+      mod: {LoggerSentry.Application, []}
+    ]
   end
 
   defp deps do
@@ -24,7 +27,8 @@ defmodule LoggerSentry.Mixfile do
       {:sentry, "~> 7.2"},
       {:jason, "~> 1.1"},
       {:excoveralls, "~> 0.10", only: :test},
-      {:ex_doc, "~> 0.19", only: [:dev, :test]}
+      {:ex_doc, "~> 0.19", only: [:dev, :test]},
+      {:mimic, "~> 1.5", only: :test}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -12,6 +12,7 @@
   "makeup_elixir": {:hex, :makeup_elixir, "0.10.0", "0f09c2ddf352887a956d84f8f7e702111122ca32fbbc84c2f0569b8b65cbf7fa", [:mix], [{:makeup, "~> 0.5.5", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "4a36dd2d0d5c5f98d95b3f410d7071cd661d5af310472229dd0e92161f168a44"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm", "69b09adddc4f74a40716ae54d140f93beb0fb8978d8636eaded0c31b6f099f16"},
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm", "f278585650aa581986264638ebf698f8bb19df297f66ad91b18910dfc6e19323"},
+  "mimic": {:hex, :mimic, "1.5.1", "085f7ebfeb5b579a13a167aec3c712d71fecfc6cb8b298c0dd3056f97ea2c2a0", [:mix], [], "hexpm", "33a50ef9ff38f8f24b2586d52e529981a3ba2b8d061c872084aff0e993bf4bd5"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.4.0", "ee261bb53214943679422be70f1658fff573c5d0b0a1ecd0f18738944f818efe", [:mix], [], "hexpm", "ebb595e19456a72786db6dcd370d320350cb624f0b6203fcc7e23161d49b0ffb"},
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm", "17ef63abde837ad30680ea7f857dd9e7ced9476cdd7b0394432af4bfc241b960"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},

--- a/test/rate_limiter/token_bucket_test.exs
+++ b/test/rate_limiter/token_bucket_test.exs
@@ -1,0 +1,56 @@
+defmodule LoggerSentry.RateLimiter.TokenBucket.Test do
+  use ExUnit.Case
+
+  alias LoggerSentry.RateLimiter.TokenBucket
+
+  setup do
+    {:ok, time_agent} = Agent.start_link(fn -> 0 end)
+    time_now = fn -> Agent.get(time_agent, & &1) end
+    step_time = fn -> Agent.update(time_agent, &(&1 + 1)) end
+    token_bucket = TokenBucket.init(token_count: 3, interval_ms: 1, time_now: time_now)
+
+    {:ok, token_bucket: token_bucket, step_time: step_time}
+  end
+
+  test "stop allowing requests when tokens are depeleted", %{token_bucket: token_bucket} do
+    assert {:ok, token_bucket} = TokenBucket.check(token_bucket)
+    assert {:ok, token_bucket} = TokenBucket.check(token_bucket)
+    assert {:ok, token_bucket} = TokenBucket.check(token_bucket)
+    assert {:skip, _} = TokenBucket.check(token_bucket)
+  end
+
+  test "tokens refill to max", %{token_bucket: token_bucket, step_time: step_time} do
+    assert {:ok, token_bucket} = TokenBucket.check(token_bucket)
+    assert {:ok, token_bucket} = TokenBucket.check(token_bucket)
+    assert {:ok, token_bucket} = TokenBucket.check(token_bucket)
+    assert {:skip, token_bucket} = TokenBucket.check(token_bucket)
+    step_time.()
+    assert {:ok, token_bucket} = TokenBucket.check(token_bucket)
+    assert {:ok, token_bucket} = TokenBucket.check(token_bucket)
+    assert {:ok, token_bucket} = TokenBucket.check(token_bucket)
+    assert {:skip, _} = TokenBucket.check(token_bucket)
+  end
+
+  test "tokens partially refill to max", %{token_bucket: token_bucket, step_time: step_time} do
+    assert {:ok, token_bucket} = TokenBucket.check(token_bucket)
+    step_time.()
+    assert {:ok, token_bucket} = TokenBucket.check(token_bucket)
+    assert {:ok, token_bucket} = TokenBucket.check(token_bucket)
+    assert {:ok, token_bucket} = TokenBucket.check(token_bucket)
+    assert {:skip, _} = TokenBucket.check(token_bucket)
+  end
+
+  test "tokens don't go above max", %{token_bucket: token_bucket, step_time: step_time} do
+    assert {:ok, token_bucket} = TokenBucket.check(token_bucket)
+    assert {:ok, token_bucket} = TokenBucket.check(token_bucket)
+    assert {:ok, token_bucket} = TokenBucket.check(token_bucket)
+    assert {:skip, token_bucket} = TokenBucket.check(token_bucket)
+    step_time.()
+    step_time.()
+    step_time.()
+    assert {:ok, token_bucket} = TokenBucket.check(token_bucket)
+    assert {:ok, token_bucket} = TokenBucket.check(token_bucket)
+    assert {:ok, token_bucket} = TokenBucket.check(token_bucket)
+    assert {:skip, _} = TokenBucket.check(token_bucket)
+  end
+end

--- a/test/rate_limiter/token_bucket_test.exs
+++ b/test/rate_limiter/token_bucket_test.exs
@@ -12,7 +12,7 @@ defmodule LoggerSentry.RateLimiter.TokenBucket.Test do
     {:ok, token_bucket: token_bucket, step_time: step_time}
   end
 
-  test "stop allowing requests when tokens are depeleted", %{token_bucket: token_bucket} do
+  test "stop allowing requests when tokens are depleted", %{token_bucket: token_bucket} do
     assert {:ok, token_bucket} = TokenBucket.check(token_bucket)
     assert {:ok, token_bucket} = TokenBucket.check(token_bucket)
     assert {:ok, token_bucket} = TokenBucket.check(token_bucket)

--- a/test/rate_limiter_test.exs
+++ b/test/rate_limiter_test.exs
@@ -1,0 +1,79 @@
+defmodule LoggerSentry.RateLimiter.Test do
+  use ExUnit.Case, async: false
+  use Mimic
+
+  alias LoggerSentry.RateLimiter
+  alias LoggerSentry.RateLimiter.{NoLimit, TokenBucket}
+
+  setup :set_mimic_global
+
+  test "rate limiter defaults to no limit" do
+    opts = [name: :NoLimit]
+    {:ok, pid} = RateLimiter.start_link(opts)
+    assert %{module: NoLimit} = :sys.get_state(pid)
+  end
+
+  test "create token bucket rate limiter with default options" do
+    opts = [
+      name: :DefaultOptions,
+      rate_limiter_module: TokenBucket
+    ]
+
+    {:ok, pid} = RateLimiter.start_link(opts)
+
+    assert %{module: TokenBucket, state: %{interval_ms: 60_000, max_tokens: 60}} =
+             :sys.get_state(pid)
+  end
+
+  test "create token bucket rate limiter with custom options" do
+    opts = [
+      name: :CustomOptions,
+      rate_limiter_module: TokenBucket,
+      rate_limiter_options: [interval_ms: 1000, token_count: 20]
+    ]
+
+    {:ok, pid} = RateLimiter.start_link(opts)
+
+    assert %{module: TokenBucket, state: %{interval_ms: 1000, max_tokens: 20}} =
+             :sys.get_state(pid)
+  end
+
+  test "send unlimited by default" do
+    me = self()
+    stub(Sentry, :capture_message, fn msg, _ -> send(me, msg) end)
+
+    tokens = 10
+
+    for n <- 0..tokens do
+      msg = "Msg #{n}"
+      RateLimiter.send_rate_limited(msg, [])
+      assert_receive ^msg
+    end
+  end
+
+  test "send until tokens depleted" do
+    me = self()
+    stub(Sentry, :capture_message, fn msg, _ -> send(me, msg) end)
+
+    tokens = 3
+
+    opts = [
+      name: :Depleted,
+      rate_limiter_module: TokenBucket,
+      rate_limiter_options: [token_count: tokens]
+    ]
+
+    assert {:ok, pid} = RateLimiter.start_link(opts)
+
+    for n <- 0..tokens do
+      msg = "Msg #{n}"
+      RateLimiter.send_rate_limited(pid, msg, [])
+
+      if n == tokens do
+        refute_receive ^msg, 1000
+      else
+        assert_receive ^msg
+      end
+    end
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,5 @@
+Mimic.copy(Sentry)
+
 ExUnit.start()
 
 :ets.new(:__just_prepare_for_logger_sentry__, [:named_table, :public])


### PR DESCRIPTION
Adds rate limiting options. By default no rate limiting is enforced for backwards compatibility. Includes a simple token bucket algorithm for rate limiting. Other rate limiting algorithms may be implemented and used too by conforming to the `LoggerSentry.RateLimiter` behaviour. 