### PR TITLE
Log failure to send message to Sentry

### DIFF
--- a/lib/logger_sentry/application.ex
+++ b/lib/logger_sentry/application.ex
@@ -8,7 +8,6 @@ defmodule LoggerSentry.Application do
     rate_limit_options = Application.get_env(:logger_sentry, LoggerSentry.RateLimiter, [])
 
     children = [
-      {Task.Supervisor, name: LoggerSentry.TaskSupervisor},
       {LoggerSentry.RateLimiter, rate_limit_options}
     ]
 

--- a/lib/logger_sentry/application.ex
+++ b/lib/logger_sentry/application.ex
@@ -8,6 +8,7 @@ defmodule LoggerSentry.Application do
     rate_limit_options = Application.get_env(:logger_sentry, LoggerSentry.RateLimiter, [])
 
     children = [
+      {Task.Supervisor, name: LoggerSentry.TaskSupervisor},
       {LoggerSentry.RateLimiter, rate_limit_options}
     ]
 

--- a/lib/logger_sentry/rate_limiter.ex
+++ b/lib/logger_sentry/rate_limiter.ex
@@ -30,6 +30,8 @@ defmodule LoggerSentry.RateLimiter do
 
   use GenServer
 
+  require Logger
+
   @name __MODULE__
 
   def start_link(opts) do
@@ -59,7 +61,7 @@ defmodule LoggerSentry.RateLimiter do
         try do
           Sentry.capture_message(output, options)
         rescue
-          _ -> :ok
+          error -> Logger.error("Failed to capture message: #{Exception.message(error)}")
         end
 
         {:noreply, new_strategy}

--- a/test/rate_limiter_test.exs
+++ b/test/rate_limiter_test.exs
@@ -84,9 +84,10 @@ defmodule LoggerSentry.RateLimiter.Test do
     opts = [unexpected: "option"]
     stub(Sentry, :capture_message, fn _, _ -> raise "error" end)
 
-    assert capture_log(fn ->
-             assert :ok = RateLimiter.send_rate_limited(pid, "message", opts)
-             Process.sleep(100)
-           end) =~ ~r/Task .* started from Unexpected terminating/
+    assert "" =
+             capture_log(fn ->
+               assert :ok = RateLimiter.send_rate_limited(pid, "message", opts)
+               Process.sleep(100)
+             end)
   end
 end

--- a/test/rate_limiter_test.exs
+++ b/test/rate_limiter_test.exs
@@ -84,10 +84,9 @@ defmodule LoggerSentry.RateLimiter.Test do
     opts = [unexpected: "option"]
     stub(Sentry, :capture_message, fn _, _ -> raise "error" end)
 
-    assert "" =
-             capture_log(fn ->
-               assert :ok = RateLimiter.send_rate_limited(pid, "message", opts)
-               Process.sleep(100)
-             end)
+    assert capture_log(fn ->
+             assert :ok = RateLimiter.send_rate_limited(pid, "message", opts)
+             Process.sleep(100)
+           end) =~ "Failed to capture message: error"
   end
 end

--- a/test/rate_limiter_test.exs
+++ b/test/rate_limiter_test.exs
@@ -2,6 +2,8 @@ defmodule LoggerSentry.RateLimiter.Test do
   use ExUnit.Case, async: false
   use Mimic
 
+  import ExUnit.CaptureLog
+
   alias LoggerSentry.RateLimiter
   alias LoggerSentry.RateLimiter.{NoLimit, TokenBucket}
 
@@ -75,5 +77,16 @@ defmodule LoggerSentry.RateLimiter.Test do
         assert_receive ^msg
       end
     end
+  end
+
+  test "does not crash rate limiter on unexpected options" do
+    pid = start_supervised!({RateLimiter, name: Unexpected})
+    opts = [unexpected: "option"]
+    stub(Sentry, :capture_message, fn _, _ -> raise "error" end)
+
+    assert capture_log(fn ->
+             assert :ok = RateLimiter.send_rate_limited(pid, "message", opts)
+             Process.sleep(100)
+           end) =~ ~r/Task .* started from Unexpected terminating/
   end
 end


### PR DESCRIPTION
`Sentry.capture_message/2` will raise when provided with unknown options:
```
GenServer LoggerSentry.RateLimiter terminating
** (NimbleOptions.ValidationError) unknown options [:erl_level, :function, :line, :module, :pid, :time, :file, :gl, :domain, :application, :mfa], valid options are: [:exception, :stacktrace, :message, :extra, :user, :tags, :request, :breadcrumbs, :level, :fingerprint, :event_source, :interpolation_parameters, :integration_meta, :handled]
    (nimble_options 1.1.1) lib/nimble_options.ex:359: NimbleOptions.validate!/2
```

Since this happens inside the rate limiter it will crash the GenServer and if it happens in quick succession it will take down the entire supervision tree due to default `max_restarts/max_seconds`.

This fix will move the call into a supervised Task.

I've considered some alternatives, you may prefer one of these or have something else in mind:
- Change from a `cast` to a `call` and make the call to Sentry in `send_rate_limited`
- `try/catch` and ignore errors
- Tune supervision